### PR TITLE
add argument "dest", array of IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ setInterval(() => {
 
 ## API
 
-### `stream = createStream(port, loopback=true)`
+### `stream = createStream(port, dest=['255.255.255.255'], loopback=true)`
 
-Stream on the port `port`. If `loopback` is false, do not output your own
-messages. Returns a Node.js stream.
+Stream on the port `port`. `dest` is an array of all the destination addresses
+on which to broadcast, by default it has only `255.255.255.255` as the
+destination. If `loopback` is false, do not output your own messages. Returns a
+Node.js stream.
 
 ### `stream.on('data', (msg) => { ... })`
 

--- a/README.md
+++ b/README.md
@@ -10,28 +10,28 @@ local area network.
 Broadcast on port `8999` on your local area network.
 
 ```js
-const createStream = require('dgram-broadcast');
+const createStream = require('dgram-broadcast')
 
-const stream = createStream(8999);
+const stream = createStream(8999)
 
 stream.on('data', (msg) => {
-  console.log(msg.toString());
-  console.log(msg.address, msg.port, msg.echo);
-});
+  console.log(msg.toString())
+  console.log(msg.address, msg.port, msg.echo)
+})
 
 setInterval(() => {
-  stream.write(Buffer.from(new Date().toString(), 'utf8'));
-}, 1000);
+  stream.write(Buffer.from(new Date().toString(), 'utf8'))
+}, 1000)
 ```
 
 ## API
 
-### `stream = createStream(port, dest=['255.255.255.255'], loopback=true)`
+### `stream = createStream(port, loopback=true, dest=['255.255.255.255'])`
 
-Stream on the port `port`. `dest` is an array of all the destination addresses
-on which to broadcast, by default it has only `255.255.255.255` as the
-destination. If `loopback` is false, do not output your own messages. Returns a
-Node.js stream.
+Stream on the port `port`. `If `loopback` is false, do not output your own
+messages. Returns a Node.js stream. `dest` is an array of all the destination
+addresses on which to broadcast, by default it has only `255.255.255.255` as the
+destination.
 
 ### `stream.on('data', (msg) => { ... })`
 

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const os = require('os')
 
 module.exports = function createStream(
   port,
-  dest = ['255.255.255.255'],
-  loopback = true
+  loopback = true,
+  destinations = ['255.255.255.255']
 ) {
   const addresses = {}
   const socket = udp.createSocket({ type: 'udp4', reuseAddr: true })
@@ -14,8 +14,8 @@ module.exports = function createStream(
 
   socket.write = function write(message) {
     if (typeof message === 'string') message = Buffer.from(message, 'utf8')
-    for (const destIP of dest) {
-      socket.send(message, 0, message.length, port, destIP)
+    for (const destination of destinations) {
+      socket.send(message, 0, message.length, port, destination)
     }
     return true
   }


### PR DESCRIPTION
## Context

UDP outbound broadcasts aren't working on Windows in Manyverse Desktop, see https://gitlab.com/staltz/manyverse/-/issues/1694

## Problem

UDP inbound is working (on Windows we can see/read the UDP broadcasts of other peers on LAN), just not outbound.

I made a simple Node.js script and ran it directly in Node.js in the Windows "Command":

```js
var dgram = require('dgram');
var client = dgram.createSocket('udp4');
var port = 26830;
client.send('foobarbaz', 0, 9, port, '255.255.255.255', function (err) {
  if (err) console.error(err);
});
```

And it gave the error `send EACCES 255.255.255.255:26830`.

Then, I tried changing the address to `192.168.1.255`, and it worked.

As a confirmation, [this StackOverflow answer](https://stackoverflow.com/questions/25836651/eacces-error-when-sending-datagram-on-windows) says that broadcasting on 255.255.255.255 on Windows 7 and higher is not supported anymore.

## Solution

I would like to allow alternative addresses so that we can broadcast to both `255.255.255.255` and `192.168.1.255` (or whatever the broadcast address is for the particular LAN in the situation).

This PR is a *not* a breaking change, it adds a 3rd argument, `destinations` which defaults to same behavior as before, while adding the possibility to have more destinations.  